### PR TITLE
fix build issue

### DIFF
--- a/src/main/groovy/de/triplet/gradle/play/AndroidPublisherHelper.groovy
+++ b/src/main/groovy/de/triplet/gradle/play/AndroidPublisherHelper.groovy
@@ -69,7 +69,7 @@ class AndroidPublisherHelper {
         return credential.createScoped(Collections.singleton(AndroidPublisherScopes.ANDROIDPUBLISHER))
     }
 
-    private HttpRequestInitializer setHttpTimeout(final HttpRequestInitializer requestInitializer, int timeout) {
+    private static HttpRequestInitializer setHttpTimeout(final HttpRequestInitializer requestInitializer, int timeout) {
         return new HttpRequestInitializer() {
             @Override
             public void initialize(HttpRequest httpRequest) throws IOException {


### PR DESCRIPTION
fixes this issue:

>> > No signature of method: static de.triplet.gradle.play.AndroidPublisherHelper.setHttpTimeout() is applicable for argument types: (com.google.api.client.googleapis.auth.oauth2.GoogleCredential, java.lang.Integer) values: [com.google.api.client.googleapis.auth.oauth2.GoogleCredential@225b9084, ...]